### PR TITLE
Handle collated file I/O (fixes #26)

### DIFF
--- a/libWENOEXT/WENOBase/globalfvMesh.H
+++ b/libWENOEXT/WENOBase/globalfvMesh.H
@@ -67,13 +67,13 @@ class globalfvMesh
         //- List of processors that require my cells 
         //  e.g.: that have this processor as neighbour
         const labelList sendToProcessor_;
-    
-        //- Pointer to the local mesh
-        autoPtr<fvMesh> localMeshPtr_;
 
         //- Pointer to the global mesh
         autoPtr<fvMesh> globalMeshPtr_;
-        
+
+        //- Pointer to the local mesh
+        autoPtr<fvMesh> localMeshPtr_;
+
         const fvMesh& globalMesh_;
         
         const fvMesh& localMesh_;

--- a/libWENOEXT/WENOBase/reconstructRegionalMesh.C
+++ b/libWENOEXT/WENOBase/reconstructRegionalMesh.C
@@ -426,7 +426,11 @@ void Foam::reconstructRegionalMesh::fileHandlerControl::setUncollated()
     // For the generation of the partial mesh the uncollated file opteration 
     // has to be used, as otherwise the MPI gets stuck calling an allGather()
     fileOperation::fileHandlerPtr_ = fileOperation::New("uncollated",false);
-    fileHandler(fileOperation::fileHandlerPtr_);
+    #if (OF_FORK_VERSION >= 2006 )
+        fileHandler(std::move(fileOperation::fileHandlerPtr_));
+    #else
+        fileHandler(fileOperation::fileHandlerPtr_);
+    #endif
 }
 
 
@@ -434,7 +438,11 @@ void Foam::reconstructRegionalMesh::fileHandlerControl::reset()
 {
     // Reset file handler to default
     fileOperation::fileHandlerPtr_ = fileOperation::New(oldFileHandlerType,false);
-    fileHandler(fileOperation::fileHandlerPtr_);
+    #if (OF_FORK_VERSION >= 2006 )
+        fileHandler(std::move(fileOperation::fileHandlerPtr_));
+    #else
+        fileHandler(fileOperation::fileHandlerPtr_);
+    #endif
 }
 
 Foam::reconstructRegionalMesh::fileHandlerControl::~fileHandlerControl()

--- a/libWENOEXT/WENOBase/reconstructRegionalMesh.H
+++ b/libWENOEXT/WENOBase/reconstructRegionalMesh.H
@@ -51,6 +51,24 @@ namespace Foam
 
 namespace reconstructRegionalMesh
 {
+    // Class to set the correct fileHandler
+    class fileHandlerControl
+    {
+        private:
+            word oldFileHandlerType;
+
+        public:
+
+            fileHandlerControl() = default;
+            
+            ~fileHandlerControl();
+            
+            // Set the file hander to uncollated
+            void setUncollated();
+
+            // Reset the file handler to the old type
+            void reset();
+    };
 
     //- Reconsturct mesh depending on processor list
     autoPtr<fvMesh> reconstruct


### PR DESCRIPTION
Set the file handler manually to uncollated for the reconstruction
of the mesh. At the end the original file handler is restored.