### PR TITLE
[BugFix] Correct initial reference frame

### DIFF
--- a/libWENOEXT/WENOBase/WENOBase.C
+++ b/libWENOEXT/WENOBase/WENOBase.C
@@ -738,11 +738,12 @@ Foam::WENOBase::WENOBase
         ownHalos_.setSize(Pstream::nProcs());
 
         // ------------------ Start Processing ---------------------------------
-        
+      
+        Info << "\t1) Init volume integrals..." << endl;
         // Initialize the volume integrals 
         initVolIntegrals(globalfvMesh);
 
-        Info << "\t1) Create local stencils..." << endl;
+        Info << "\t2) Create local stencils..." << endl;
         createStencilID(globalMesh,globalfvMesh.localToGlobalCellID(),nStencils,extendRatio);
         
         // Copy globalStencilID list to stencilID 
@@ -752,7 +753,7 @@ Foam::WENOBase::WENOBase
         // Correct stencilID list to local cellID values 
         if(Pstream::parRun())
         {
-            Info << "\t2) Create haloCells ... " << endl;
+            Info << "\t\t) Create haloCells ... " << endl;
             correctParallelRun(globalfvMesh,nStencils);
         }
         

--- a/libWENOEXT/WENOBase/geometryWENO/geometryWENO.H
+++ b/libWENOEXT/WENOBase/geometryWENO/geometryWENO.H
@@ -182,6 +182,8 @@ namespace geometryWENO
             const scalar x3, const scalar y3, const scalar z3
         );
 
+        bool checkReferenceFrame(const labelList& refFrame, const pointField& pts);
+
         // Const array for Gauss quadratur 7th order
         // Coefficients can be found in 
         //   Quadrature Formulas in Two DimensionsMath 5172 


### PR DESCRIPTION
The initial reference frame could have less than 3 edges or give a singular
Jacobi matrix which leads to a fatal error in the Foam::det() function.

Now all possible reference frames are checked and if the first possible one is
found it is selected. Hence, avoiding the second while loop.

This commit introduces the checkReferenceFrame() function.