### PR TITLE
Update reconstructRegionalMesh.C for compilation of >= OF-v2312

### DIFF
--- a/libWENOEXT/WENOBase/reconstructRegionalMesh.C
+++ b/libWENOEXT/WENOBase/reconstructRegionalMesh.C
@@ -509,7 +509,7 @@ void Foam::reconstructRegionalMesh::fileHandlerControl::setUncollated()
     // has to be used, as otherwise the MPI gets stuck calling an allGather()
     fileOperation::fileHandlerPtr_ = fileOperation::New("uncollated",false);
     #if (OF_FORK_VERSION >= 2006 )
-        fileHandler(std::move(fileOperation::fileHandlerPtr_));
+        fileOperation::fileHandler(std::move(fileOperation::fileHandlerPtr_));
     #else
         fileHandler(fileOperation::fileHandlerPtr_);
     #endif
@@ -521,7 +521,7 @@ void Foam::reconstructRegionalMesh::fileHandlerControl::reset()
     // Reset file handler to default
     fileOperation::fileHandlerPtr_ = fileOperation::New(oldFileHandlerType,false);
     #if (OF_FORK_VERSION >= 2006 )
-        fileHandler(std::move(fileOperation::fileHandlerPtr_));
+        fileOperation::fileHandler(std::move(fileOperation::fileHandlerPtr_));
     #else
         fileHandler(fileOperation::fileHandlerPtr_);
     #endif


### PR DESCRIPTION
The compilation didn't work since the fileHandler function wasn't found during compilation with OF-v2312. Therefore I added `fileOperation::` in front to make `wmake` find the function during operation. The WENO tutorials were afterwards tested for OF-v2312 and worked properly.